### PR TITLE
Add: add merchant link test, fix post /merchants path

### DIFF
--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,8 +1,8 @@
 <h1>All Merchants</h1>
-<%= link_to "Add New Merchant", "/admin/merchants/new" %>
+<div id="new-link-top"><%= link_to "Add New Merchant", "/admin/merchants/new" %></div>
 <br>
 <% @merchants.each do |merchant| %>
 <li id="merchant-<%= merchant.id%>"><%= merchant.name %> - status: <%= merchant.status %></li>
 <% end %>
 <br>
-<%= link_to "Add New Merchant", "/admin/merchants/new" %>
+<div id="new-link-bottom"><%= link_to "Add New Merchant", "/admin/merchants/new" %></div>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -3,8 +3,8 @@
 <%= form_with url: '/admin/merchants', method: :post, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
-
-  <%# <%= f.hidden_field :status, :value => "disabled" %> %>
+  
+  <%= f.hidden_field :status, :value => "disabled" %>
 
   <%= f.submit "Submit" %>
 <% end %>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,10 +1,10 @@
 <h1>Add a New Merchant</h1>
 
-<%= form_with url: '/admin/merchants/create', method: :post, local: true do |f| %>
+<%= form_with url: '/admin/merchants', method: :post, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
 
-  <%= f.hidden_field :status, :value => "disabled" %>
+  <%# <%= f.hidden_field :status, :value => "disabled" %> %>
 
   <%= f.submit "Submit" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     get '/merchants', to: 'merchants#index'
     get '/merchants/new', to: 'merchants#new'
     get '/merchants/:id', to: 'merchants#show'
-    post '/merchants/create', to: 'merchants#create'
+    post '/merchants', to: 'merchants#create'
     get '/merchants/:id/edit', to: 'merchants#edit'
     patch '/merchants/:id', to: 'merchants#update'
   end

--- a/spec/features/admin/merchants/create_spec.rb
+++ b/spec/features/admin/merchants/create_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe 'Creating a new merchant:', type: :feature do
   it 'happy path' do
     visit '/admin/merchants'
 
-    expect(page).to have_link("Add New Merchant")
-    click_link("Add New Merchant")
+    within("#new-link-top") do
+      expect(page).to have_link("Add New Merchant")
+      click_link("Add New Merchant")
+    end
 
     expect(current_path).to eq('/admin/merchants/new')
 
@@ -22,7 +24,12 @@ RSpec.describe 'Creating a new merchant:', type: :feature do
   end
 
   it 'does not create merchant if Name field is empty' do
-    visit '/admin/merchants/new'
+    visit '/admin/merchants'
+
+    within("#new-link-bottom") do
+      expect(page).to have_link("Add New Merchant")
+      click_link("Add New Merchant")
+    end
 
     click_button("Submit")
     expect(current_path).to eq('/admin/merchants/new')


### PR DESCRIPTION
Just a couple small changes to User Story https://github.com/turingschool-examples/little-esty-shop/issues/12 for the Admin Merchant Create feature:

- Added an ID to the top and bottom links to "Add a New Merchant" on the Admin Merchant Index page, the test was failing because it didn't know which of the two links to click on. There are now tests for each of them.
- revised the route & inbound links from `post '/merchants/create'` to just `post '/merchants'` to be more RESTful