### PR TITLE
Migration adjustment

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,6 +6,7 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
 
   validates_presence_of :name
+  validates_presence_of :status
 
   enum status: { "disabled" => 0, "enabled" => 1 }
 end

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -4,5 +4,7 @@
   <%= f.label :name %>
   <%= f.text_field :name %>
 
+  <%= f.hidden_field :status, :value => "disabled" %>
+
   <%= f.submit "Submit" %>
 <% end %>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -4,7 +4,5 @@
   <%= f.label :name %>
   <%= f.text_field :name %>
 
-  <%# <%= f.hidden_field :status, :value => "disabled" %> %>
-
   <%= f.submit "Submit" %>
 <% end %>

--- a/db/migrate/20220219221647_add_status_to_merchant.rb
+++ b/db/migrate/20220219221647_add_status_to_merchant.rb
@@ -1,5 +1,5 @@
 class AddStatusToMerchant < ActiveRecord::Migration[5.2]
   def change
-    add_column :merchants, :status, :integer
+    add_column :merchants, :status, :integer, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2022_02_19_221647) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status"
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|


### PR DESCRIPTION
I added a default value to the `add_status_to_merchant` migration. All merchants from the CSV now have a status of 'disabled' instead of being blank. 

After merging this & pulling back to your machine, YOU WILL NEED TO:

- rails db:drop
- rails db:create
- rails db:migrate
- rails csv_load:all

We'll also need to reset the database on Heroku once main is updated.