### PR TITLE
Nav buttons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,8 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
-
+  <button><a href="/admin">Admin</a></button>  <button><a href="/admin/merchants"> Admin Merchants</a></button>
+      <button><a href="/admin/invoices">Admin invoices</a></button>
   <body>
     <% flash.each do |type, msg| %>
       <div>

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Invoices', type: :feature do
 
 
   # I think we are looking at the invoices index on the admin side - Katy
-  xit "Admin invoice index page" do
+  it "Admin invoice index page" do
 
     visit "/admin/invoices"
 


### PR DESCRIPTION
These buttons are for easier navigation through the primary admin pages. They should be removed before the project is turned in.